### PR TITLE
Some code improvements and bug fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{mem::take, fmt::Write};
+use std::fmt::Write;
 
 use proc_macro::{Delimiter, Spacing, TokenTree};
 
@@ -283,8 +283,6 @@ fn parse_var(
     let mut prev = None;
 
     if group.delimiter() == Delimiter::Bracket {
-        let mut add = String::new();
-
         let mut stream = group.stream().into_iter();
 
         while let Some(mut var) = stream.next() {
@@ -309,7 +307,7 @@ fn parse_var(
             if new == "NONE" {
                 values.push(String::new())
             } else {
-                values.push(duplicate(&(take(&mut add) + &new), vars));
+                values.push(duplicate(&new, vars));
             }
         }
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,8 +280,6 @@ fn parse_var(
             return (name, values);
         };
 
-    let mut prev = None;
-
     if group.delimiter() == Delimiter::Bracket {
         let mut stream = group.stream().into_iter();
 
@@ -290,6 +288,7 @@ fn parse_var(
             while !matches!(&var, TokenTree::Punct(p) if p.as_char() == ',') {
                 match &var {
                     TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => {
+                        let mut prev = None;
                         for tt in g.stream() {
                             fold_tt(&mut new, tt, &mut prev)
                         }
@@ -312,6 +311,7 @@ fn parse_var(
         }
     } else {
         let mut fold = String::new();
+        let mut prev = None;
         for tt in group.stream() {
             fold_tt(&mut fold, tt, &mut prev)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 ///             println!("false");
 ///         }
 ///     ];
-///     
+///
 ///     if *var < 0 {
 ///         *code
 ///     }
@@ -90,7 +90,7 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 /// ```
 ///
 /// ## NONE
-/// `NONE` is the way you can tell `akin` to simply skip that value and not write anything.  
+/// `NONE` is the way you can tell `akin` to simply skip that value and not write anything.
 /// It is useful for when you want to have elements in a duplication that do not have to be in the others.
 /// ```
 /// # use akin::akin;
@@ -105,7 +105,7 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 ///         }
 ///     ];
 ///
-///     println!("*num^2 = {}", *num~u32*code);  
+///     println!("*num^2 = {}", *num~u32*code);
 ///     // *num~u32 is necessary to ensure the type is written correctly (it would be "1 u32" without it)
 ///     # writeln!(&mut out, "*num^2 = *numu32*code");
 /// }
@@ -113,7 +113,7 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 /// ```
 ///
 /// ## Joint modifier
-/// By default, `akin` places a space between all identifiers.  
+/// By default, `akin` places a space between all identifiers.
 /// Sometimes, this is not desirable, for example, if trying to interpolate between a function name
 /// ```compile_fail
 /// # use akin::akin;
@@ -130,7 +130,7 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 /// To avoid it, use the joint modifier `~`, making the next identifier not to be separated.
 /// ```
 /// # use akin::akin;
-/// akin! {  
+/// akin! {
 ///     let &name = [1];
 ///     fn _~*name() // *name is affected by the modifier
 /// # {}
@@ -163,7 +163,7 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 ///         },
 ///         NONE
 ///     ];
-///     
+///
 ///     let &num = [1,     2,    3,  4];
 ///     let &res = [1., 1.41, 1.73,  2.];
 ///     let &branch = {
@@ -173,7 +173,7 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 ///     impl Sqrt for *int_type {
 ///         fn dumb_sqrt(self) -> Result<f64, &'static str> {
 ///             *negative_check
-///             
+///
 ///             match self {
 ///                 *branch
 ///                 _ => Err("Sqrt of num not in [1, 4]")
@@ -199,7 +199,7 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 ///         if self < 0 {
 ///             return Err("Sqrt of negative number")
 ///         }
-///         
+///
 ///         match self {
 ///             1 => Ok(1.),
 ///             2 => Ok(1.41),
@@ -247,7 +247,7 @@ pub fn akin(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         &mut previous,
     );
     let out_raw = tokens.fold(init, |acc, tt| fold_tt(acc, tt, &mut previous));
-    
+
     let out = duplicate(&out_raw, &vars);
 
     //let tokens = format!("proc_macro: {:#?}", input.into_iter().collect::<Vec<_>>());
@@ -359,7 +359,7 @@ fn get_used_vars<'a>(
             }
         }
     }
-    
+
     (used, times)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ fn parse_var(
 ) -> (String, Vec<String>) {
     let name = format!(
         "*{}",
-        tokens.next().expect("akin: expected code to duplicate")
+        tokens.next().expect("akin: expected variable name after 'let &'")
     );
 
     if !matches!(tokens.next(), Some(TokenTree::Punct(p)) if p.as_char() == '=') {
@@ -273,12 +273,10 @@ fn parse_var(
     }
 
     let mut values: Vec<String> = Vec::new();
-    let group =
-        if let TokenTree::Group(g) = tokens.next().expect("akin: expected code to duplicate") {
-            g
-        } else {
-            return (name, values);
-        };
+    let group = match tokens.next() {
+        Some(TokenTree::Group(g)) => g,
+        _ => panic!("akin: expected bracketed or braced group after '&{}='", &name[1..]),
+    };
 
     if group.delimiter() == Delimiter::Bracket {
         let mut stream = group.stream().into_iter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,14 +353,13 @@ fn get_used_vars<'a>(
     let mut times = 0;
     let mut indices = std::collections::HashSet::new();
     for (name, values) in vars.iter().rev() {
-        let matches = stream.match_indices(name);
-        for (m, _) in matches {
-            if !indices.contains(&m) {
-                indices.insert(m);
-                used.push((name, values));
-                times = times.max(values.len());
-                break;
-            }
+        let present = stream.match_indices(name).fold(false, |acc, (m, _)| {
+            indices.insert(m) || acc
+        });
+
+        if present {
+            used.push((name, values));
+            times = times.max(values.len());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,11 +326,7 @@ fn parse_var(
 fn duplicate(stream: &str, vars: &Map<String, Vec<String>>) -> String {
     let chunks = Chunk::new(stream).split_by_vars(vars);
 
-    let times = chunks.iter().map(|c| c.times()).max().unwrap_or(0);
-
-    if times <= 0 {
-        return stream.into();
-    }
+    let times = chunks.iter().map(|c| c.times()).max().unwrap_or(1).max(1);
 
     let total_len = chunks.iter().map(|c| c.total_len(times)).sum();
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -195,3 +195,26 @@ fn var_replace_code() {
         assert_eq!(*bar, "correct");
     }
 }
+
+#[test]
+fn zero_tokens() {
+    akin! {}
+}
+
+#[test]
+fn one_token() {
+    let x = akin! {
+        "test"
+    };
+    assert_eq!(x, "test");
+}
+
+#[test]
+fn one_token_repeated() {
+    let x = akin::akin! {
+        let &x = [1, 2];
+        let &b = {test~*x};
+        "*b"
+    };
+    assert_eq!(x, " test1 test2");
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -218,3 +218,11 @@ fn one_token_repeated() {
     };
     assert_eq!(x, " test1 test2");
 }
+
+#[test]
+fn modifier_carry_over_bug() {
+    akin::akin! {
+        let &x = [{1~} 2 {3}];
+        assert_eq!("*x", " 12 3");
+    };
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -272,3 +272,12 @@ fn repeated_substitution_bug() {
     };
     assert_eq!(x, "x*y");
 }
+
+#[test]
+fn replace_no_variants_bug() {
+    akin! {
+        let &x = [];
+        assert_eq!("*x", "");
+        assert_eq!("*y", "*y");
+    };
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -197,6 +197,42 @@ fn var_replace_code() {
 }
 
 #[test]
+fn var_replace_global_bug() {
+    let mut v = Vec::new();
+    akin! {
+        let &foo = [1, 2, 3];
+        let &foobar = [correct];
+        v.push("*foobar *foobar");
+    };
+    assert_eq!(v.as_slice(), &["correct correct"]);
+}
+
+#[test]
+fn var_replace_value_bug() {
+    let mut v = Vec::new();
+    akin! {
+        let &foo = [1, 2, 3];
+        let &foobar = [correct];
+        let &bar = [*foobar *foobar];
+        v.push("*bar");
+    }
+    assert_eq!(v.as_slice(), &["correctcorrect"]);
+}
+
+#[test]
+fn var_replace_code_bug() {
+    let mut v = Vec::new();
+    akin! {
+        let &foo = [1, 2, 3];
+        let &foobar = ["correct"];
+        let &bar = { v.push(*foobar); v.push(*foobar); };
+
+        *bar
+    }
+    assert_eq!(v.as_slice(), &["correct", "correct"]);
+}
+
+#[test]
 fn zero_tokens() {
     akin! {}
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -262,3 +262,13 @@ fn modifier_carry_over_bug() {
         assert_eq!("*x", " 12 3");
     };
 }
+
+#[test]
+fn repeated_substitution_bug() {
+    let x = akin::akin! {
+        let &y = [x];
+        let &z = [y];
+        "*y**z"
+    };
+    assert_eq!(x, "x*y");
+}


### PR DESCRIPTION
I wonder if I could interest you in this contribution. This fixes several substitution bugs, I won't go into depth about them, as the bugs were relatively subtle. See individual commit messages and the new tests for details. [Fix multiplicity calculation when one variable is prefix of another](https://github.com/LyonSyonII/akin/commit/6eb44b8128fa73e03b11718f823f08c66a94bb70) and [Fix repeated substitution bug](https://github.com/LyonSyonII/akin/commit/4353ab64af7d7fd50877df4c06acbdb6310c1592) are probably the most important ones. You can also take the new tests and run them on the original code to see what was broken and how.

Still, there's no telling if some user hasn't depended on it, and some user templates might be not accepted or produce different results now, so a major version bump might be in order.