### PR TITLE
[New Feature] Unsigned integer ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ Because the variables `&lhs` and `&rhs` both have 3 values.
 
 As you can see, `&` is used to declare variables and `*` is used to "dereference" them to the current value.
 
+As a matter of convenience, the range syntax is also accepted, when declaring a variable,
+e.g. `0..3` and `0..=3`, which are equivalent to `[0,1,2]` and `[0,1,2,3]` respectively.
+So the above example could also be written like
+
+```rust
+let &lhs = 1..=3;
+let &rhs = 4..=6;
+println!("*lhs + *rhs = {}", *lhs + *rhs);
+```
+
+Presently, only unsigned integers that can fit in `u64` are supported in ranges, i.e. ranges
+like `-10..-1` or `'a'..'c'`, which are fine in regular Rust, aren't accepted by `akin`.
+
 If a used variable has less values than another, the last one will be used.
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,19 @@ use proc_macro::{Delimiter, Spacing, TokenTree};
 /// }
 /// ```
 ///
+/// ## Range syntax
+/// As a matter of convenience, the range syntax is also accepted, when declaring a variable,
+/// e.g. `0..3` and `0..=3`, which are equivalent to `[0,1,2]` and `[0,1,2,3]` respectively.
+/// So the variables `a` and `b` in the example above could also be declared like
+///
+/// ```ignore
+/// let &a = 1..=6;
+/// let &b = 4..=6;
+/// ```
+///
+/// Presently, only unsigned integers that can fit in `u64` are supported in ranges, i.e. ranges
+/// like `-10..-1` or `'a'..'c'`, which are fine in regular Rust, aren't accepted by `akin`.
+///
 /// ## NONE
 /// `NONE` is the way you can tell `akin` to simply skip that value and not write anything.
 /// It is useful for when you want to have elements in a duplication that do not have to be in the others.

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -281,3 +281,23 @@ fn replace_no_variants_bug() {
         assert_eq!("*y", "*y");
     };
 }
+
+#[test]
+fn range_expression() {
+    let x = akin::akin! {
+        let &x = 1..10;
+        let &y = {*x};
+        "*y"
+    };
+    assert_eq!(x, " 1 2 3 4 5 6 7 8 9");
+}
+
+#[test]
+fn range_expression_inclusive() {
+    let x = akin::akin! {
+        let &x = 1..=10;
+        let &y = {*x,};
+        [*y]
+    };
+    assert_eq!(x, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+}


### PR DESCRIPTION
This PR adds the possibility to declare substitution variables with range syntax. For example,
`let &x = 0..10;`, which is equivalent to the longer declaration of `let &x = [0,1,2,3,4,5,6,7,8,9];`.

Since `akin!` previously rejected variable declarations that didn't involve some kind of group after the `=`,
this new syntax doesn't conflict with anything a user could have written.

When working with macros that accept a variable number of arguments (e.g. `sqlx::query!`), one often finds
themselves needing to write things like `macro!(arr[0], arr[1], arr[2],...)`. 

`akin!` could help with this, but the best one can do with it presently is to spell all the numbers out manually in
a `let &x = [0, 1, 2, ...]`, which winds up being not much shorter. The addition of the range syntax would
eliminate some whole screens of repetitive code in some of my use-cases, so I hope for this PR to get merged.